### PR TITLE
Allow empty root key for empty collections

### DIFF
--- a/lib/active_model/serializer/collection_serializer.rb
+++ b/lib/active_model/serializer/collection_serializer.rb
@@ -48,6 +48,7 @@ module ActiveModel
         key ||= object.respond_to?(:name) ? object.name && object.name.underscore : nil
         # 4. key may be nil for empty collection and no serializer option
         key &&= key.pluralize
+        key || ''
       end
       # rubocop:enable Metrics/CyclomaticComplexity
 

--- a/lib/active_model/serializer/collection_serializer.rb
+++ b/lib/active_model/serializer/collection_serializer.rb
@@ -48,8 +48,6 @@ module ActiveModel
         key ||= object.respond_to?(:name) ? object.name && object.name.underscore : nil
         # 4. key may be nil for empty collection and no serializer option
         key &&= key.pluralize
-        # 5. fail if the key cannot be determined
-        key || fail(ArgumentError, 'Cannot infer root key from collection type. Please specify the root or each_serializer option, or render a JSON String')
       end
       # rubocop:enable Metrics/CyclomaticComplexity
 

--- a/test/collection_serializer_test.rb
+++ b/test/collection_serializer_test.rb
@@ -95,16 +95,12 @@ module ActiveModel
         resource = []
         resource.define_singleton_method(:name) { nil }
         serializer = collection_serializer.new(resource)
-        assert_raise ArgumentError do
-          serializer.json_key
-        end
+        assert_nil serializer.json_key
       end
 
       def test_json_key_with_resource_without_name_and_no_serializers
         serializer = collection_serializer.new([])
-        assert_raise ArgumentError do
-          serializer.json_key
-        end
+        assert_nil serializer.json_key
       end
 
       def test_json_key_with_empty_resources_with_serializer

--- a/test/collection_serializer_test.rb
+++ b/test/collection_serializer_test.rb
@@ -95,12 +95,12 @@ module ActiveModel
         resource = []
         resource.define_singleton_method(:name) { nil }
         serializer = collection_serializer.new(resource)
-        assert_nil serializer.json_key
+        assert_equal '', serializer.json_key
       end
 
       def test_json_key_with_resource_without_name_and_no_serializers
         serializer = collection_serializer.new([])
-        assert_nil serializer.json_key
+        assert_equal '', serializer.json_key
       end
 
       def test_json_key_with_empty_resources_with_serializer


### PR DESCRIPTION
## Why

This recent change cause some problem with our codebase, and it seems easier to fix by reverting this.

## What

Revert the change


