### PR TITLE
Allow skipping action controller railtie

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -147,6 +147,7 @@ module ActiveModel
     config.jsonapi_include_toplevel_object = false
     config.jsonapi_use_foreign_key_on_belongs_to_relationship = false
     config.include_data_default = true
+    config.mixes_action_controller = true
 
     # For configuring how serializers are found.
     # This should be an array of procs.

--- a/lib/active_model_serializers/railtie.rb
+++ b/lib/active_model_serializers/railtie.rb
@@ -13,7 +13,10 @@ module ActiveModelSerializers
       ActiveModel::Serializer.serializers_cache.clear
     end
 
-    # We sometimes do not want this mix
+    # We sometimes do not want this mix, for example in application.rb, you can have:
+    # config.before_initialize do
+    #   ActiveModelSerializers.config.mixes_action_controller = false
+    # end
     initializer 'active_model_serializers.action_controller' do
       if ActiveModelSerializers.config.mixes_action_controller
         ActiveSupport.on_load(:action_controller) do

--- a/lib/active_model_serializers/railtie.rb
+++ b/lib/active_model_serializers/railtie.rb
@@ -13,9 +13,12 @@ module ActiveModelSerializers
       ActiveModel::Serializer.serializers_cache.clear
     end
 
+    # We sometimes do not want this mix
     initializer 'active_model_serializers.action_controller' do
-      ActiveSupport.on_load(:action_controller) do
-        include(::ActionController::Serialization)
+      if ActiveModelSerializers.config.mixes_action_controller
+        ActiveSupport.on_load(:action_controller) do
+          include(::ActionController::Serialization)
+        end
       end
     end
 

--- a/test/active_model_serializers/railtie_test_isolated.rb
+++ b/test/active_model_serializers/railtie_test_isolated.rb
@@ -41,6 +41,25 @@ class RailtieTest < ActiveSupport::TestCase
     end
   end
 
+  class WithRailsRequiredFirstWithoutMix < RailtieTest
+    class ActiveModelSerializers
+      include ActiveSupport::Configurable
+    end
+
+    setup do
+      ActiveModelSerializers.config.mixes_action_controller = false
+      require 'rails'
+      require 'active_model_serializers'
+    end
+
+    test 'does not mix ActionController::Serialization into ActionController::Base' do
+      assert ActionController.const_defined?(:Serialization),
+        'ActionController::Serialization should not be defined'
+      refute ::ActionController::Base.included_modules.include?(::ActionController::Serialization),
+        'ActionController::Serialization should not be included'
+    end
+  end
+
   class WithoutRailsRequiredFirst < RailtieTest
     setup do
       require 'active_model_serializers'


### PR DESCRIPTION
## Why

In our use case, we do not want to have Serialization mixed within ActionController

## What

Add the ability to skip the railtie.