### PR TITLE
Enable selective fields in nested association

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -370,14 +370,12 @@ module ActiveModel
         options[:fields] = fieldset.fields_for(json_key)
       end
       # [Note] Add this clause to provide selective fields for associations in json adapter.
-      if !options[:fields]
+      unless options[:fields]
         h = options[:include_directive].to_hash
         fields = []
-        fields += h[:fields].keys if h.has_key?(:fields)
-        fields += h[:only].keys   if h.has_key?(:only)
-        if fields.size > 0
-          options[:fields] = fields
-        end
+        fields += h[:fields].keys if h.key?(:fields)
+        fields += h[:only].keys   if h.key?(:only)
+        options[:fields] = fields unless fields.empty?
       end
 
       resource = attributes_hash(adapter_options, options, adapter_instance)

--- a/lib/active_model/serializer/association.rb
+++ b/lib/active_model/serializer/association.rb
@@ -58,15 +58,7 @@ module ActiveModel
         association_object = association_serializer && association_serializer.object
         return unless association_object
 
-        # Add this clause to filter fields for associations.
-        # Because attribute adapter doesn't provide fields selection of nested associations.
-        if adapter_options[:include] && adapter_options[:include].is_a?(Hash) && adapter_options[:include][key] && adapter_options[:include][key].is_a?(Hash)
-          fields = [adapter_options[:include][key][:fields] || adapter_options[:include][key][:only] || []].flatten.compact
-          options = fields.present? ? { fields: fields } : {}
-        else
-          options = {}
-        end
-        serialization = association_serializer.serializable_hash(adapter_options, options, adapter_instance)
+        serialization = association_serializer.serializable_hash(adapter_options, {}, adapter_instance)
 
         if polymorphic? && serialization
           polymorphic_type = association_object.class.name.underscore

--- a/lib/active_model/serializer/association.rb
+++ b/lib/active_model/serializer/association.rb
@@ -49,9 +49,6 @@ module ActiveModel
       end
 
       # @api private
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/PerceivedComplexity
       def serializable_hash(adapter_options, adapter_instance)
         association_serializer = lazy_association.serializer
         return virtual_value if virtual_value
@@ -67,9 +64,6 @@ module ActiveModel
 
         serialization
       end
-      # rubocop:enable Metrics/CyclomaticComplexity
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/PerceivedComplexity
 
       private
 

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -155,12 +155,12 @@ module ActiveModelSerializers
           actual = ActiveModelSerializers::SerializableResource.new(
             [@first_post, @second_post], adapter: :json, fields: %w(id author.id), include: {
               author: {
-                fields: [:name],
+                fields: [:name]
               },
               comments: {
                 fields: [:id],
                 author: {
-                  fields: [:id],
+                  fields: [:id]
                 }
               }
             }
@@ -169,7 +169,7 @@ module ActiveModelSerializers
           expected = {
             posts: [
               { id: 1, author: { name: 'Steve K.' }, comments: [{ id: 3, author: { id: 4 } }] },
-              { id: 2, author: { name: 'Steve K.' }, comments: [] },
+              { id: 2, author: { name: 'Steve K.' }, comments: [] }
             ]
           }
           assert_equal(expected, actual)

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -145,6 +145,35 @@ module ActiveModelSerializers
           expected = { posts: [{ id: 1, author: { id: 1, name: 'Steve K.' } }, { id: 2, author: { id: 1, name: 'Steve K.' } }] }
           assert_equal(expected, actual)
         end
+
+        def test_fields_with_nested_associations_include_option_with_sub_fields
+          # Setup
+          @first_post.comments = [Comment.new(id: 3, author: Author.new(id: 4, name: 'John L.'))]
+          ActionController::Base.cache_store.clear
+
+          # Test
+          actual = ActiveModelSerializers::SerializableResource.new(
+            [@first_post, @second_post], adapter: :json, fields: %w(id author.id), include: {
+              author: {
+                fields: [:name],
+              },
+              comments: {
+                fields: [:id],
+                author: {
+                  fields: [:id],
+                }
+              }
+            }
+          ).as_json
+
+          expected = {
+            posts: [
+              { id: 1, author: { name: 'Steve K.' }, comments: [{ id: 3, author: { id: 4 } }] },
+              { id: 2, author: { name: 'Steve K.' }, comments: [] },
+            ]
+          }
+          assert_equal(expected, actual)
+        end
       end
     end
   end


### PR DESCRIPTION
## Why
In current implementation, `fields` option is ignored in nested association.

## What
Support `fields` option in nested association.

@tomoasleep @CamilleDrapier 
Please review this 🙇 

## Diff
`test_fields_with_nested_associations_include_option_with_sub_fields` fails in the current `0-10-stable` branch.
`fields` option in `commets.author` is ignored, which causes this error.

```console
[2020/03/23 16:13:36] ~/.go/src/github.com/wantedly/active_model_serializers (0-10-stable)
$ BUNDLER_VERSION=1.17.3 bundle exec rake test
.
.
.
  1) Failure:
ActiveModelSerializers::Adapter::Json::Collection#test_fields_with_nested_associations_include_option_with_sub_fields [/Users/minami/.go/src/github.com/wantedly/active_model_serializers/test/adapter/json/collection_test.rb:175]:
--- expected
+++ actual
@@ -1 +1 @@
-{:posts=>[{:id=>1, :comments=>[{:id=>3, :author=>{:id=>4}}], :author=>{:name=>"Steve K."}}, {:id=>2, :comments=>[], :author=>{:name=>"Steve K."}}]}
+{:posts=>[{:id=>1, :comments=>[{:id=>3, :author=>{:name=>"John L."}}], :author=>{:name=>"Steve K."}}, {:id=>2, :comments=>[], :author=>{:name=>"Steve K."}}]}
```